### PR TITLE
[DOC] Changement d'équipe

### DIFF
--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -1,6 +1,6 @@
 # Changer d'équipe
 
-Au sein de Pix, il est possible de passer d'une des équipes Engineering à une autre, si le contexte le permet. 
+Au sein de Pix, il est possible de passer d'une équipe Engineering à une autre, si le contexte le permet. 
 
 ## Pourquoi changer d'équipe ?
 

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -30,7 +30,7 @@ Pour le premier cas, une simple discussion pour prévoir l'échange suffit.
 
 Les étapes pour un changement temporaire : 
 * le/la dev doit en discuter avec son équipe (PO+LD, et les dev) pour s'assurer que son absence ne posera pas problème
-* les PO et LD des équipes, avec le/la dev concerné(e), en discute pour prévoir les dates de début et de fin
+* les PO et LD des équipes, avec le/la dev concerné(e), en discutent pour prévoir les dates de début et de fin
 * le/la dev l'annonce sur le slack #engineering, et lors du Weekly Meeting Dev 
 
 ### Changement permanent

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -12,9 +12,9 @@ Au sein de Pix, il est possible de passer d'une équipe Engineering à une autre
 ## Le besoin de changer d'équipe
 
 Le changement d'équipe peut se faire suite :
-* A une envie d'un(e) dev de changer d'équipe ou de voir d'autres contextes
-* A une suggestion d'un(e) manager ou d'un(e) lead-dev
-* A un besoin de renforcement d'une autre équipe
+* À l'envie d'un(e) dev de changer d'équipe ou de voir d'autres contextes
+* À la suggestion d'un(e) manager ou d'un(e) lead-dev
+* Au besoin de renforcement d'une autre équipe
 
 ## Les types de changements
 

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -1,9 +1,9 @@
 # Changer d'équipe
 
-Au sein de Pix, il est possible de passer d'une équipe Engineering à une autre, si le contexte le permet. 
+Au sein de Pix, il est possible de passer d'une équipe Engineering à une autre, si le contexte le permet.
 
 ## Pourquoi changer d'équipe ?
-
+Quelques raisons qui pourraient motiver un(e) dev à changer d'équipe :
 * Pour voir de nouveaux contextes
 * Pour se challenger
 * Pour apporter une nouvelle vision aux équipes
@@ -28,18 +28,18 @@ Pour le premier cas, une simple discussion pour prévoir l'échange suffit.
 
 ### Changement temporaire
 
-Les étapes pour un changement temporaire : 
+Les étapes pour un changement temporaire :
 * le/la dev doit en discuter avec son équipe (PO+LD, et les dev) pour s'assurer que son absence ne posera pas problème
 * les PO et LD des équipes, avec le/la dev concerné(e), en discutent pour prévoir les dates de début et de fin
-* le/la dev l'annonce sur le slack #engineering, et lors du Weekly Meeting Dev 
+* le/la dev l'annonce sur le slack #engineering, et lors du Weekly Meeting Dev
 
 ### Changement permanent
 
 Les étapes pour un changement permanent :
 * le/la dev doit en discuter avec son ou sa manager Pix s'il/elle est interne
 * le/la dev doit en discuter avec son équipe (PO+LD+dev) pour annoncer son envie de changement et s'assurer que son départ ne posera pas problème
-* le/la dev annonce son envie de changer d'équipe lors du Weekly Meeting Dev
-* suite à cette annonce : 
+* le/la dev peut annoncer son envie de changer d'équipe lors du Weekly Meeting Dev (si la personne souhaite des retours sur son envie)
+* ensuite : 
   * le/la dev peut passer ponctuellement du temps avec les autres équipes
   * le/la dev peut demander si une équipe en particulier a besoin de renfort
 
@@ -52,4 +52,3 @@ Une fois l'équipe cible identifiée :
 ### Documents utiles :
 
 Le document représentant l'état des équipes (disponible via le lien "Les équipes" sur le slack #engineering) permet de noter quand une personne souhaite changer d'équipe, ou si une équipe a des besoins.
-

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -46,7 +46,7 @@ Les étapes pour un changement permanent :
 Une fois l'équipe cible identifiée :
 * le/la dev échange avec toute la future équipe (PO+LD+dev)
 * Les PO et LD des deux équipes, avec le/la dev, décide d'une date de changement
-* Le LD de la future équipe prévoit un O3 avec l'arrivant
+* Le/la LD de la future équipe prévoit un O3 avec l'arrivant
 * le/la dev annonce le changement d'équipe lors du Weekly Meeting Dev et sur #engineering
 
 ### Documents utiles :

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -45,7 +45,7 @@ Les étapes pour un changement permanent :
 
 Une fois l'équipe cible identifiée :
 * le/la dev échange avec toute la future équipe (PO+LD+dev)
-* Les PO et LD des deux équipes, avec le/la dev, décide d'une date de changement
+* Les PO et LD des deux équipes, avec le/la dev, décident d'une date de changement
 * Le/la LD de la future équipe prévoit un O3 avec l'arrivant
 * le/la dev annonce le changement d'équipe lors du Weekly Meeting Dev et sur #engineering
 

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -7,7 +7,7 @@ Au sein de Pix, il est possible de passer d'une équipe Engineering à une autre
 * Pour voir de nouveaux contextes
 * Pour se challenger
 * Pour apporter une nouvelle vision aux équipes
-* Pour faciliter l'alignement des pratiques entre les teams
+* Pour faciliter l'alignement des pratiques entre les équipes
 
 ## Le besoin de changer d'équipe
 

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -1,0 +1,55 @@
+# Changer d'équipe
+
+Au sein de Pix, il est possible de passer d'une des équipes Engineering à une autre, si le contexte le permet. 
+
+## Pourquoi changer d'équipe ?
+
+* Pour voir de nouveaux contextes
+* Pour se challenger
+* Pour apporter une nouvelle vision aux équipes
+* Pour faciliter l'alignement des pratiques entre les teams
+
+## Le besoin de changer d'équipe
+
+Le changement d'équipe peut se faire suite :
+* A une envie d'un(e) dev de changer d'équipe ou de voir d'autres contextes
+* A une suggestion d'un(e) manager ou d'un(e) lead-dev
+* A un besoin de renforcement d'une autre équipe
+
+## Les types de changements
+
+Un(e) dev peut changer d'équipe :
+* Le temps d'un atelier ou d'un mob : c'est l'histoire de quelques heures
+* De façon temporaire, le temps d'un sprint ou d'une epix : durant plusieurs semaines
+* De façon permanente : la personne rejoint la nouvelle équipe.
+
+Pour le premier cas, une simple discussion pour prévoir l'échange suffit.
+
+
+### Changement temporaire
+
+Les étapes pour un changement temporaire : 
+* le/la dev doit en discuter avec son équipe (PO+LD, et les dev) pour s'assurer que son absence ne posera pas problème
+* les PO et LD des équipes, avec le/la dev concerné(e), en discute pour prévoir les dates de début et de fin
+* le/la dev l'annonce sur le slack #engineering, et lors du Weekly Meeting Dev 
+
+### Changement permanent
+
+Les étapes pour un changement permanent :
+* le/la dev doit en discuter avec son manager Pix s'il/elle est interne
+* le/la dev doit en discuter avec son équipe (PO+LD+dev) pour annoncer son envie de changement et s'assurer que son départ ne posera pas problème
+* le/la dev annonce son envie de changer d'équipe lors du Weekly Meeting Dev
+* suite à cette annonce : 
+  * le/la dev peut passer du temps ponctuelle avec les autres équipes
+  * le/la dev peut demander s'il y a un besoin particulier sur une équipe
+
+Une fois l'équipe cible identifiée :
+* le/la dev échange avec toute la future équipe (PO+LD+dev)
+* Les PO et LD des deux équipes, avec le/la dev, décide d'une date de changement
+* Le LD de la future équipe prévoit un O3 avec l'arrivant
+* le/la dev annonce le changement d'équipe lors du Weekly Meeting Dev et sur #engineering
+
+### Documents utiles :
+
+Le document représentant l'état des équipes (disponible via le lien "Les équipes" sur le slack #engineering) permet de noter quand une personne souhaite changer d'équipe, ou si une équipe a des besoins.
+

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -40,8 +40,8 @@ Les étapes pour un changement permanent :
 * le/la dev doit en discuter avec son équipe (PO+LD+dev) pour annoncer son envie de changement et s'assurer que son départ ne posera pas problème
 * le/la dev annonce son envie de changer d'équipe lors du Weekly Meeting Dev
 * suite à cette annonce : 
-  * le/la dev peut passer du temps ponctuelle avec les autres équipes
-  * le/la dev peut demander s'il y a un besoin particulier sur une équipe
+  * le/la dev peut passer ponctuellement du temps avec les autres équipes
+  * le/la dev peut demander si une équipe en particulier a besoin de renfort
 
 Une fois l'équipe cible identifiée :
 * le/la dev échange avec toute la future équipe (PO+LD+dev)

--- a/organisation/changement-d-equipe.md
+++ b/organisation/changement-d-equipe.md
@@ -36,7 +36,7 @@ Les étapes pour un changement temporaire :
 ### Changement permanent
 
 Les étapes pour un changement permanent :
-* le/la dev doit en discuter avec son manager Pix s'il/elle est interne
+* le/la dev doit en discuter avec son ou sa manager Pix s'il/elle est interne
 * le/la dev doit en discuter avec son équipe (PO+LD+dev) pour annoncer son envie de changement et s'assurer que son départ ne posera pas problème
 * le/la dev annonce son envie de changer d'équipe lors du Weekly Meeting Dev
 * suite à cette annonce : 


### PR DESCRIPTION
📝 Documentation 📝

Suite à des échanges sur nos moyens de permettre à des devs de changer d'équipe, ce document est proposé pour continuer de discuter et enfin valider comment nous gérons les changements d'équipes.

Avoir une documentation plus clair était aussi une action de la réunion de juin 2022 sur les changements au sein des équipes.