### PR TITLE
Ajout des adresses courriel et blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ Nous sommes actuellement à la recherche de [développeurs ou développeuses *fu
 
 ## Nous retrouver !
 
-Par mail : 
-Sur notre blog : 
+Par courriel : engineering@pix.fr  
+Sur notre blog : http://engineering.pix.fr/


### PR DESCRIPTION
## :unicorn: Problème
Le fichier readme n'indique pas l'adresse courriel ni celle du blog technique.

## :robot: Proposition
Ajout des adresses manquantes.

## :rainbow: Remarques
Je n'étais plus sûr pour l'adresse courriel.

## :100: Pour tester
Cliquer sur les adresses et vérifier que les liens sont valides et cohérentes.
