### PR TITLE
Supprimer les offres d'emploi déjà pourvues

### DIFF
--- a/recrutement/README.md
+++ b/recrutement/README.md
@@ -1,9 +1,7 @@
 # Recrutement
 
 Pix cherche actuellement :
-- [Un(e) CTO](cto.md)
 - [Un(e) Data Engineer](data-engineering.md)
-- [Un(e) SRE](sre.md)
 - [Un(e) développeur(euse) Full-stack JS](dev-full-stack.md) pour [les équipes](../organisation/equipes.md)
 
 


### PR DESCRIPTION
## :unicorn: Problème
Certaines offres d'emploi sont déjà pourvues

## :robot: Proposition
Les suppprimer

## :rainbow: Remarques
Est-ce utile de les faire figurer si le lien WTJ liste celles à jour ?

## :100: Pour tester
Relire
